### PR TITLE
Allow testing with basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.zip
 build/
 node_modules
+*.cred.json
 lines_of_code.csv
 .nyc_output/

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ zipfiles := $(pkgfiles:%/package.json=%.zip)
 all: $(zipfiles)
 	@:
 
-%.zip: %
+%.zip: % %/node_modules
 	cd $< ; zip -x '*.tt' '*.yml' 'node_modules/.bin/*' -r $(abspath $@) .
 
 %/node_modules: %/package.json %/yarn.lock
+	mkdir -p $@
 	cd `dirname $@` ; yarn --only=prod --no-optional
 	# unfortunately too many devices are old and dirty
 	# and fail, so we run with - to ignore the return value

--- a/com.wikicfp/manifest.tt
+++ b/com.wikicfp/manifest.tt
@@ -1,4 +1,6 @@
-class @com.wikicfp {
+class @com.wikicfp
+#_[name="WikiCFP"]
+#_[description="Keep updated with paper submission deadlines"] {
   import loader from @org.thingpedia.v2();
   import config from @org.thingpedia.config.none();
 

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,13 @@ async function loadDeviceFactory(deviceKind) {
 async function createDeviceInstance(deviceKind, factory) {
     if (factory.metadata.auth.type === 'none')
         return new factory(mockEngine, { kind: deviceKind });
+    if (factory.metadata.auth.type === 'basic') {
+        // credentials are stored in test/[DEVICE ID].cred.json
+        const credentialsPath = path.resolve(path.dirname(module.filename), deviceKind + '.cred.json');
+        const arguments = require(credentialsPath);
+        arguments.kind = deviceKind
+        return new factory(mockEngine, arguments)
+    }
 
     // otherwise do something else...
     return null;

--- a/test/index.js
+++ b/test/index.js
@@ -65,9 +65,9 @@ async function createDeviceInstance(deviceKind, factory) {
     if (factory.metadata.auth.type === 'basic') {
         // credentials are stored in test/[DEVICE ID].cred.json
         const credentialsPath = path.resolve(path.dirname(module.filename), deviceKind + '.cred.json');
-        const arguments = require(credentialsPath);
-        arguments.kind = deviceKind
-        return new factory(mockEngine, arguments)
+        const args = require(credentialsPath);
+        args.kind = deviceKind
+        return new factory(mockEngine, args)
     }
 
     // otherwise do something else...

--- a/test/index.js
+++ b/test/index.js
@@ -64,10 +64,10 @@ async function createDeviceInstance(deviceKind, factory) {
         return new factory(mockEngine, { kind: deviceKind });
     if (factory.metadata.auth.type === 'basic') {
         // credentials are stored in test/[DEVICE ID].cred.json
-        const credentialsPath = path.resolve(path.dirname(module.filename), deviceKind + '.cred.json');
+        const credentialsPath = path.resolve('./test', deviceKind + '.cred.json');
         const args = require(credentialsPath);
-        args.kind = deviceKind
-        return new factory(mockEngine, args)
+        args.kind = deviceKind;
+        return new factory(mockEngine, args);
     }
 
     // otherwise do something else...


### PR DESCRIPTION
Support for testing with basic auth

#### Usage
Place the files as
```text
test/[YOUR DEVICE ID].js
test/[YOUR DEVICE ID].cred.json
```

If basic auth is set in the `[YOUR DEVICE ID]/manifest.tt`, you can test the device with specified credentials.