### PR TITLE
Fixed temperature spelling error

### DIFF
--- a/main/org.thingpedia.iot.temperature/dataset.tt
+++ b/main/org.thingpedia.iot.temperature/dataset.tt
@@ -31,7 +31,7 @@ dataset @org.thingpedia.iot.temperature language "en" {
                  "the temperature of the ${p_name:const} temperature sensor",
                  "the temperature of the ${p_name:const}",
                  "the temperature in the ${p_name:const}",
-                 "the ${p_name:const} temperatue"]];
+                 "the ${p_name:const} temperature"]];
 
   stream (p_name : String) := monitor(@org.thingpedia.iot.temperature(name=p_name).temperature())
   #_[utterances=["when the ${p_name:const} temperature changes"]];


### PR DESCRIPTION
Spelling error in dataset.tt "temperatue" replaced with "temperature"